### PR TITLE
Edit campaign, prevent edit-delete btn if not owner

### DIFF
--- a/client/src/Components/CampaignCard/CampaignCard.js
+++ b/client/src/Components/CampaignCard/CampaignCard.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { MDBCard, MDBBtn, MDBCardBody, MDBCardImage, MDBCardText, MDBCardTitle, MDBRow } from 'mdbreact';
 import { withAuth } from '@okta/okta-react';
 import './CampaignCard.scss';
 
 class CampaignCard extends React.Component {
   render() {
-    const { campaign } = this.props;
+    const { campaign, userDbId } = this.props;
 
     return (
       <div className="CampaignCard">
@@ -22,14 +23,20 @@ class CampaignCard extends React.Component {
                 Campaign Stats
               </MDBBtn>
             </MDBRow>
-            <MDBRow around>
-              <MDBBtn className="campaign-card-button" outline color="warning">
-                Edit
-              </MDBBtn>
-              <MDBBtn className="campaign-card-button" outline color="danger">
-                Delete
-              </MDBBtn>
-            </MDBRow>
+            {userDbId === campaign.ownerId ? (
+              <MDBRow around>
+                <Link to={{ pathname: '/campaignform', state: { campaign, isEditing: true } }}>
+                  <MDBBtn className="campaign-card-button" outline color="warning">
+                    Edit
+                  </MDBBtn>
+                </Link>
+                <MDBBtn className="campaign-card-button" outline color="danger">
+                  Delete
+                </MDBBtn>
+              </MDBRow>
+            ) : (
+              ''
+            )}
           </MDBCardBody>
         </MDBCard>
       </div>

--- a/client/src/Pages/Campaign/Campaign.js
+++ b/client/src/Pages/Campaign/Campaign.js
@@ -12,6 +12,7 @@ class Campaign extends React.Component {
   state = {
     myCampaigns: [],
     isLoading: true,
+    userDbId: -1,
   };
 
   getAccessToken = async () => {
@@ -48,14 +49,15 @@ class Campaign extends React.Component {
     campaignRequests.getUserCampaigns(dbRequest.accessToken, dbRequest.dbUid).then((resp) => {
       this.setState({
         myCampaigns: resp,
+        userDbId: dbRequest.dbUid,
       });
     });
   };
 
   render() {
-    const { myCampaigns, isLoading } = this.state;
+    const { myCampaigns, isLoading, userDbId } = this.state;
 
-    const campaignCards = (myCampaigns) => myCampaigns.map((campaign, index) => <CampaignCard key={campaign.id} campaign={campaign} />);
+    const campaignCards = (myCampaigns) => myCampaigns.map((campaign, index) => <CampaignCard key={campaign.id} campaign={campaign} userDbId={userDbId} />);
 
     return (
       <div className="Campaign">

--- a/client/src/Pages/Campaign/CampaignForm/CampaignForm.js
+++ b/client/src/Pages/Campaign/CampaignForm/CampaignForm.js
@@ -72,7 +72,12 @@ class CampaignForm extends React.Component {
     campaign.ownerId = dbRequestObj.dbUid;
 
     if (this.props.location.state.isEditing) {
-      console.log('Edit goes here');
+      campaignRequests
+        .updateCampaign(dbRequestObj.accessToken, campaign)
+        .then((resp) => {
+          this.props.history.push('/campaigns');
+        })
+        .catch((error) => console.error('There was a problem updating your campaign', error));
     } else {
       campaignRequests
         .createCampaign(dbRequestObj.accessToken, campaign)

--- a/client/src/helpers/data/campaignRequests.js
+++ b/client/src/helpers/data/campaignRequests.js
@@ -35,4 +35,20 @@ const createCampaign = (token, newCampaign) =>
       });
   });
 
-export default { getUserCampaigns, createCampaign };
+const updateCampaign = (token, updatedCampaign) =>
+  new Promise((resolve, reject) => {
+    axios
+      .put(`${dmiApiBaseUrl}/campaigns`, updatedCampaign, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      })
+      .then((resp) => {
+        resolve(resp);
+      })
+      .catch((error) => {
+        reject(error);
+      });
+  });
+
+export default { getUserCampaigns, createCampaign, updateCampaign };

--- a/server/Controllers/CampaignsController.cs
+++ b/server/Controllers/CampaignsController.cs
@@ -42,5 +42,17 @@ namespace DMInsights.Controllers
             }
             return newCampaign;
         }
+
+        [HttpPut]
+        public ActionResult<Campaign> UpdateCampaign([FromBody] Campaign updatedCampaignObj)
+        {
+            var updatedCampaign = _campaignsRepo.UpdateCampaign(updatedCampaignObj);
+
+            if (updatedCampaign == null)
+            {
+                return BadRequest();
+            }
+            return Ok(updatedCampaign);
+        }
     }
 }

--- a/server/Data/CampaignsRepository.cs
+++ b/server/Data/CampaignsRepository.cs
@@ -85,5 +85,30 @@ namespace DMInsights.Data
             throw new Exception("Could not create new campaign");
         }
 
+        public Campaign UpdateCampaign(Campaign campaignObj)
+        {
+            using(var db = new SqlConnection(_connectionString))
+            {
+                var updateCampaignQuery = @"
+                        UPDATE
+                            [Campaigns]
+                        SET
+                            [Title] = @Title,
+                            [Description] = @Description,
+                            [ImageUrl] = @ImageUrl
+                        WHERE
+                            Id = @id";
+
+                var rowsAffected = db.Execute(updateCampaignQuery, campaignObj);
+
+                if (rowsAffected != 1)
+                {
+                    return null; ;
+                }
+                return campaignObj;
+            }
+            throw new Exception("Could not update the campaign");
+        }
+
     }
 }


### PR DESCRIPTION
Closes #15 

- Added API Endpoint for Edit
- Prevent Edit/Delete buttons if you are not the owner of the campaign
- Added Front End UI and functionality for Edit